### PR TITLE
LibBigWig 0.3.0 and WiggleTools 1.2.1 (new formulas)

### DIFF
--- a/clark.rb
+++ b/clark.rb
@@ -12,6 +12,7 @@ class Clark < Formula
     sha256 "1ef50d25121c19b6567f3e5112897a08887189672bf408abeb24979fdbd061b5" => :el_capitan
     sha256 "361ed1106de564e044f96ce1ca82dd894c684ddf7ff58e417533cf567d71fa14" => :yosemite
     sha256 "52acdda74cbcec8a4815d998136784d8769c7c1e7efc7eeb2eab8a44552cbf98" => :mavericks
+    sha256 "c7a4f65621a89f894109a50dda5c9614e64808fc30e6d449b8831f44a3be96bf" => :x86_64_linux
   end
 
   needs :openmp

--- a/clark.rb
+++ b/clark.rb
@@ -31,6 +31,6 @@ class Clark < Formula
   end
 
   test do
-    assert_match "k-spectrum", shell_output("CLARK 2>&1", 255)
+    assert_match "k-spectrum", shell_output("#{bin}/CLARK 2>&1", 255)
   end
 end

--- a/libbigwig.rb
+++ b/libbigwig.rb
@@ -1,0 +1,24 @@
+class Libbigwig < Formula
+  desc "C library for handling bigWig files"
+  homepage "https://github.com/dpryan79/libBigWig"
+  url "https://github.com/dpryan79/libBigWig/archive/0.3.0.tar.gz"
+  sha256 "221002fe249e8099009f0790f44bfe991e85cb23763cf5fc494e745c0160edc2"
+
+  depends_on "curl"
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+    cp_r "test", prefix
+    cp "Makefile", prefix
+    cp Dir.glob("*.o"), prefix
+    cp Dir.glob("*.pico"), prefix
+  end
+
+  test do
+    cp_r prefix/"test", testpath
+    cp prefix/"Makefile", testpath
+    cp Dir.glob(prefix/"*.o"), testpath
+    cp Dir.glob(prefix/"*.pico"), testpath
+    system "make", "test"
+  end
+end

--- a/wiggletools.rb
+++ b/wiggletools.rb
@@ -1,0 +1,24 @@
+class Wiggletools < Formula
+  desc "Compute genome-wide statistics with composable iterators"
+  homepage "https://github.com/Ensembl/WiggleTools"
+  url "https://github.com/Ensembl/WiggleTools/archive/v1.2.1.tar.gz"
+  sha256 "906d32e281fe234b3eacbe569c21e68d61aca3d0ef2eec501e4efd61799be4ee"
+
+  depends_on "htslib"
+  depends_on "libbigwig"
+  depends_on "gsl"
+
+  def install
+    system "make"
+    cp_r "test", prefix
+    cp_r "bin", prefix
+    cp "Makefile", prefix
+  end
+
+  test do
+    cp_r prefix/"test", testpath
+    cp_r prefix/"bin", testpath
+    cp prefix/"Makefile", testpath
+    system "make", "test"
+  end
+end


### PR DESCRIPTION
Dear homebrew-science maintainers,

Please find attached two recipes for a tool that I developed [WiggleTools](https://github.com/Ensembl/WiggleTools) and a nifty library it depends on [libBigWig](https://github.com/dpryan79/libBigWig). 

Both repos have a few stars, so are hopefully of interest to the community. Both are also quite stable, as you can see from the relative absence of updates in the past few months. 

Thank you,

Daniel

### Have you:

- [Y] Followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-science/blob/master/.github/CONTRIBUTING.md) document?
- [Y] Checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-science/pulls) for the same update/change?
- [Y] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [Y] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [Y] Written a sensible test? (The best test is to compile and run a sample program.)